### PR TITLE
Detect sudo on scripts and commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 commando
+.idea

--- a/main.go
+++ b/main.go
@@ -45,9 +45,14 @@ func main() {
 		color.Magenta("on hosts")
 		color.Yellow(fmt.Sprintf("%v", hosts))
 
-		pswd, err := prompt(args)
-		if err != nil {
-			dief("failed to read password: %v", err)
+		var pswd string
+		for _, script := range scripts {
+			if script.sudo {
+				pswd, err = prompt(args)
+				if err != nil {
+					dief("failed to read password: %v", err)
+				}
+			}
 		}
 
 		if err := run(args.user, pswd, hosts, scripts); err != nil {

--- a/scripts.go
+++ b/scripts.go
@@ -20,10 +20,11 @@ type script struct {
 	stdin   []string
 }
 
-// A scriptfile contains one or more scripts to be executed.
+// A scriptfile contains one or more scripts to be executed. the first line is the command and the second line is stdin
 type scriptfile struct {
 	name    string
 	scripts []script
+	sudo    bool
 }
 
 func (s scriptfile) String() string {
@@ -69,10 +70,14 @@ func read(name, path string) (scriptfile, error) {
 }
 
 func parse(name, content string) (scriptfile, error) {
+	// --- is a "key" string which causes us to create a new "script" from a single file
 	parts := strings.Split(content, "---")
 	scriptfile := scriptfile{name: name}
 
 	for _, part := range parts {
+		if strings.Contains(part, "PASSWORD") {
+			scriptfile.sudo = true
+		}
 		lines := cleanup(strings.Split(part, "\n"))
 		if len(lines) == 0 {
 			return scriptfile, errors.Errorf("no command in script %s", name)
@@ -117,12 +122,14 @@ func run(user, pass string, hosts []string, files []scriptfile) error {
 
 func runCmd(user string, hosts []string, command string, pw bool) error {
 	var pass string
-	if pw {
+
+	if pw || strings.Contains(command, "sudo") {
 		var err error
 		pass, err = easyPrompt(user)
 		if err != nil {
 			return err
 		}
+		pw = true
 	}
 	for _, host := range hosts {
 		client, err := makeClient(user, pass, host)


### PR DESCRIPTION
Because scripts need to define their stdin we're detecting it based on
whether or not the keyword we're using for password replacement is
included in the script, "PASSWORD"

For commands we're looking for the word "sudo" in the command.